### PR TITLE
Add cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - Go directive bumped from 1.15 to 1.26, gofmt the codebase, and fix
   staticcheck findings ([a2ba36c])
 - Bumped `PuerkitoBio/goquery` from 1.6.1 to 1.13.0 ([21a782a])
+- Added `cooldown: default-days: 7` to dependabot updates to satisfy the
+  zizmor `dependabot-cooldown` audit ([9f8a43e])
 
 ## [1.3.1]
 
@@ -60,3 +62,4 @@ All notable changes to this project will be documented in this file.
 [c42abd1]: https://github.com/LeakIX/l9format/commit/c42abd1
 [7ed9cc3]: https://github.com/LeakIX/l9format/commit/7ed9cc3
 [21a782a]: https://github.com/LeakIX/l9format/commit/21a782a
+[9f8a43e]: https://github.com/LeakIX/l9format/commit/9f8a43e


### PR DESCRIPTION
The zizmor `dependabot-cooldown` audit flags the implicit default-days (less than 7) on weekly dependabot updates. This sets `cooldown: default-days: 7` explicitly on both the gomod and github-actions ecosystems, clearing the finding.

Model: mlx/ddalcu/Qwen3.8-27B-MLX-Serve-4bit